### PR TITLE
update SFB1394 logo

### DIFF
--- a/_data/affiliated-projects.yml
+++ b/_data/affiliated-projects.yml
@@ -44,7 +44,7 @@
   link: http://molmod.github.io/QuickFF/
 -
   name: SFB
-  image_path: https://pbs.twimg.com/profile_images/1229479188022865920/NTT0sArw_400x400.jpg
+  image_path: https://www.sfb1394.rwth-aachen.de/fileadmin/IMM-Web/Resources/Public/Images/Logos/SFB1394_Logo_217x80_DE.png
   link: https://www.sfb1394.rwth-aachen.de
 -
   name: SPHInX


### PR DESCRIPTION
The logo from their webpage is newer than the twitter one and apparently it's the one coordinated with the RWTH PR, so I just update the link here.