### PR TITLE
Fix collaborators

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,7 +1,7 @@
 links:
   -
     - name: Getting started
-      link: /getting-started/
+      link: /getting-started
       new_window: false
       download: false
     - name: Documentation
@@ -18,7 +18,7 @@ links:
       new_window: true
       download: false
     - name: Privacy Policy
-      link: /privacy/
+      link: /privacy
       new_window: false
       download: false
     - name: License

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,9 +1,9 @@
 - name: Team
-  link: /team/
+  link: /team
   new_window: false
   highlight: false
 - name: Collaborators
-  link: /collaborators/
+  link: /collaborators
   new_window: false
   highlight: false
 - name: Publications

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,7 +7,7 @@
 			{% assign class = class | append: " highlight" %}
 		{% endif %}
 
-		{% if link.link == page.url %}
+		{% if page.url contains link.link %}
 			{% assign class = class | append: " active" %}
 		{% endif %}
 		<a href="{% include relative-src.html src=link.link %}" class="{{ class }}" {% if link.new_window %}target="_blank"{% endif %}>{{ link.name }}</a>

--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -68,7 +68,7 @@
 	transition: .3s transform cubic-bezier(.155,1.105,.295,1.12),.3s box-shadow,.3s -webkit-transform cubic-bezier(.155,1.105,.295,1.12);
 	padding: 14px 80px 18px 36px;
 	margin: 10px auto;
-	width: 80%;
+	width: 50%;
 	height: auto;
 	background-repeat: no-repeat;
     background-position: right;


### PR DESCRIPTION
the trailing `/` character in several urls caused them to be hidden on the github remote server, even though they render fine locally. Manually removing the `/` character fixes the pages on the site, but many of our links point to the url with trailing `/`.

I removed these characters from all urls except `news/` and `publications/` where they actually are folders.