### PR TITLE
sort posts by category with js

### DIFF
--- a/_includes/list-posts.html
+++ b/_includes/list-posts.html
@@ -1,13 +1,13 @@
 {% assign n_posts=0 %}
 {% for post in include.posts %}
 	{% assign n_posts = n_posts | plus: 1 %}
-	<li class="blog-post" id="post{{n_posts}}">
+	<li class="blog-post" id="post-{{n_posts}}" data-categories="{{ post.categories }}">
 		<a href="{{ post.url }}"><h2>{{ post.title }}</h2></a>
 		<h3>
 			{% assign first = true %}
 			{% for author in post.authors %}
 				{% if first != true %}
-					 | 
+					| 
 				{% endif %}
 				{{ author }}
 				{% assign first = false %}
@@ -52,6 +52,22 @@
 	};
 
 	function loadPosts(i) {
+
+		//  filter posts by category
+		var category = "";
+		var posts_in_category = [];
+		if (window.location.hash) {
+			var hash = window.location.hash.substring(1);
+			var category = hash.replace("category=", "");
+		}
+		for (j=1; j<=n_posts; j++) {
+			if (category.length && !$("#post-"+j).attr("data-categories").includes(category)) {
+				$("#post-"+j).hide();
+			} else {
+				posts_in_category.push(j);
+			}
+		}
+
 		if (i == 0) {
 			$("#newer").hide();
 		} else {
@@ -62,14 +78,40 @@
 		} else {
 			$("#older").show();
 		}
-		for (j=0; j<=n_posts; j++) {
-			if (j <= i || j > i+n_allowed) {
-				$("#post"+j).hide();
+
+		var n_newer_hidden = 0;
+		var n_older_hidden = 0;
+
+		for (j=0; j<posts_in_category.length; j++) {
+			var postId = "#post-" + posts_in_category[j];
+			if (j < i) {
+				$(postId).hide();
+				n_newer_hidden += 1;
+			} else if (j > i+n_allowed-1) {
+				$(postId).hide();
+				n_older_hidden += 1;
 			} else {
-				$("#post"+j).show();
+				$(postId).show();
 			}
 		};
+
+		if (n_newer_hidden == 0) {
+			$("#newer").hide();
+		} else {
+			$("#newer").show();
+		}
+		if (n_older_hidden == 0) {
+			$("#older").hide();
+		} else {
+			$("#older").show();
+		}
+
 	};
 
-	loadPosts(0);
+	window.onload = function () {
+		loadPosts(0);
+	}
+	window.onhashchange = function() {
+		loadPosts(0);
+	};
 </script>

--- a/_includes/list-posts.html
+++ b/_includes/list-posts.html
@@ -68,17 +68,6 @@
 			}
 		}
 
-		if (i == 0) {
-			$("#newer").hide();
-		} else {
-			$("#newer").show();
-		}
-		if (i >= n_posts - n_allowed) {
-			$("#older").hide();
-		} else {
-			$("#older").show();
-		}
-
 		var n_newer_hidden = 0;
 		var n_older_hidden = 0;
 

--- a/_includes/list-posts.html
+++ b/_includes/list-posts.html
@@ -53,7 +53,8 @@
 
 	function loadPosts(i) {
 
-		//  filter posts by category
+		//  filter posts by category specified in url hash
+		// e.g. pyiron.org/news/#category=releases
 		var category = "";
 		var posts_in_category = [];
 		if (window.location.hash) {

--- a/_includes/post-title.html
+++ b/_includes/post-title.html
@@ -2,7 +2,8 @@
 	{% for category in include.post.categories %}
 		{% if category != "news" and category != "publications" %}
 			<span class="blog-filter">
-				<a href="{{ site.baseurl }}/category/{{ category | slugify }}/">{{ category | capitalize }}</a>
+				<a href="{{ site.baseurl }}/{{ include.post.categories[0] }}/#category={{ category | slugify }}"
+				   onclick="loadPosts(0);">{{ category | capitalize }}</a>
 			</span>
 		{% endif %}
 	{% endfor %}

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ description: Optimized protocols and data management for high-powered research
 				{% for category in post.categories %}
 					{% if category != "news" %}
 						<span class="blog-filter">
-							<a href="{{ site.baseurl }}/category/{{ category | slugify }}/">
+							<a href="{{ site.baseurl }}/news#category={{ category | slugify }}">
 								{{ category }}
 							</a>
 						</span>

--- a/publications/index.html
+++ b/publications/index.html
@@ -10,6 +10,14 @@ tall_bg: true
 		to host it here, please <a onclick="$('#formbutton-button')[0].click();">let us know!</a>
 	</p>
 	<ul class="blog-posts">
-		{% include list-posts.html posts=site.categories.publications %}
+		<!-- Our simple category filter, since gh-pages doesn't support jekyll-archives -->
+		{% if page.url contains "#category=" %}
+			{% assign category = page.url | split: "#category=" | last %}
+		{% else %}
+			<!-- will include all news posts -->
+			{% assign category = "publications" %}
+		{% endif %}
+
+		{% include list-posts.html posts=site.categories.publications category=category %}
 	</ul>
 </div>


### PR DESCRIPTION
resolves #79

I expanded the function `loadPosts` in list-posts.html to filter blog posts by their category if one has been selected. Instead of serving categories from a separate url like `https://pyiron.org/category/releases`, it just filters irrelevant posts from the blog page itself. 

```javascript
function loadPosts(i) {

    //  filter posts by category specified in url hash
    // e.g. pyiron.org/news/#category=releases
    var category = "";
    var posts_in_category = [];
    if (window.location.hash) {
        var hash = window.location.hash.substring(1);
        var category = hash.replace("category=", "");
    }
    for (j=1; j<=n_posts; j++) {
        if (category.length && !$("#post-"+j).attr("data-categories").includes(category)) {
            $("#post-"+j).hide();
        } else {
            posts_in_category.push(j);
        }
    }
.
.
. 
// show posts, etc.
```

So `loadPosts` now hides all posts on the page that don't share the category specified by the hash "#category-`category_name`" at the end of the page's url. It's a bit of a workaround - this is not at all what url hashes are meant for - but it's the only way to link to category pages from other sites/pages (for example `https://pyiron.org/news/#category=releases`)

I don't think this trick works on internet explorer [since it doesn't support hashes](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash), but I have not met anyone using explorer in quite some time :shrug: Anyway it does work for the Edge browser.