### PR TITLE
Relative urls

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@ permalink: /404.html
 sitemap: false
 ---
 <div class="four-zero-four">
-    <img src="/images/404.png"></img>
+    <img src="{{ 'images/404.png' | relative_url }}"></img>
     <p>The page you were looking for doesn't exist.</p>
     <p>If you think it ought to exist, <a onclick="$('.formbutton')[0].click();">let us know</a>.</p>
 </div>

--- a/_includes/formbutton.html
+++ b/_includes/formbutton.html
@@ -37,7 +37,6 @@
         type: "submit"
         }],
         styles: {
-        fontFamily:'"San Francisco", "Helvetica Neue", "Helvetica", "Arial"',
         button: {
             border: "2px solid {{ site.colors.main }}",
             background: "white",

--- a/_includes/list-posts.html
+++ b/_includes/list-posts.html
@@ -2,7 +2,7 @@
 {% for post in include.posts %}
 	{% assign n_posts = n_posts | plus: 1 %}
 	<li class="blog-post" id="post-{{n_posts}}" data-categories="{{ post.categories }}">
-		<a href="{{ post.url }}"><h2>{{ post.title }}</h2></a>
+		<a href="{{ post.url | relative_url }}"><h2>{{ post.title }}</h2></a>
 		<h3>
 			{% assign first = true %}
 			{% for author in post.authors %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,6 +10,6 @@
 		{% if page.url contains link.link %}
 			{% assign class = class | append: " active" %}
 		{% endif %}
-		<a href="{% include relative-src.html src=link.link %}" class="{{ class }}" {% if link.new_window %}target="_blank"{% endif %}>{{ link.name }}</a>
+		<a href="{{ link.link | relative_url }}" class="{{ class }}" {% if link.new_window %}target="_blank"{% endif %}>{{ link.name }}</a>
 	{% endfor %}
 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,9 +8,9 @@
 		{% seo %}
 		{% feed_meta %}
 
-		<link rel="stylesheet" href="{{ site.baseurl }}/css/screen.css">
+		<link rel="stylesheet" href="{{ 'css/screen.css' | relative_url }}">
 		
-		<link rel="icon" type="image/png" href="{{ site.baseurl }}/favicon.png">
+		<link rel="icon" type="image/png" href="{{ 'favicon.png' | relative_url }}">
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 		<script src="https://kit.fontawesome.com/1d40be1112.js" crossorigin="anonymous"></script>
 
@@ -27,7 +27,7 @@
 		<header>
 			<div class="container no-padding">
 				{% if page.url != "/" %}
-					<div class="company-name"><a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/logo.png" alt="pyiron Logo" width="100" height="100"/></a></div>
+					<div class="company-name"><a href="{{ site.baseurl }}/"><img src="{{ 'images/logo.png' | relative_url }}" alt="pyiron Logo" width="100" height="100"/></a></div>
 				{% endif %}
 				{% include navigation.html %}
 			</div>
@@ -35,12 +35,11 @@
 		{{ content }}
 		<footer>
 			<div class="container no-padding">
-				<p class="editor-link"><a href="cloudcannon:collections/_data/footer.yml" class="btn"><strong>&#9998;</strong> Edit footer</a></p>
 				<div class="footer-columns">
 					{% for column in site.data.footer.links %}
 					<ul class="footer-links">
 						{% for link in column %}
-						<li><a {% if link.new_window %}target="_blank"{% endif %} href="{% include relative-src.html src=link.link %}" {% if link.download %}download{% endif %}>
+						<li><a {% if link.new_window %}target="_blank"{% endif %} href="{{ link.link | relative_url }}" {% if link.download %}download{% endif %}>
 							{{ link.name }}</a></li>
 						{% endfor %}
 					</ul>
@@ -48,7 +47,7 @@
 				</div>
 				<div class="social">
 					{% for link in site.data.footer.social %}
-						<a href="{{ link.link }}" class="social-link fa fa-{{ link.icon }}"></a>
+						<a href="{{ link.link }}" target="_blank" class="social-link fa fa-{{ link.icon }}"></a>
 					{% endfor %}
 				</div>
 				<p class="copyright">&copy; {{ site.time | date: '%Y' }} {{ site.copyright }}</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,10 +21,10 @@ layout: page
 
 		<div class="blog-navigation">
 			{% if page.next_in_category.url %}
-				<a class="prev" href="{% include relative-src.html src=page.next_in_category.url %}"><i class="fa fa-arrow-left"></i> {{ page.next_in_category.title }}</a>
+				<a class="prev" href="{{ page.next_in_category.url | relative_url }}"><i class="fa fa-arrow-left"></i> {{ page.next_in_category.title }}</a>
 			{% endif %}
 			{% if page.previous_in_category.url %}
-				<a class="next" href="{% include relative-src.html src=page.previous_in_category.url %}">{{ page.previous_in_category.title }} <i class="fa fa-arrow-right"></i></a>
+				<a class="next" href="{{ page.previous_in_category.url | relative_url }}">{{ page.previous_in_category.title }} <i class="fa fa-arrow-right"></i></a>
 			{% endif %}
 		</div>
 

--- a/_sass/elements.scss
+++ b/_sass/elements.scss
@@ -8,7 +8,7 @@ html, body {
 }
 
 body {
-	font-family: "San Francisco", "Helvetica Neue", "Helvetica", "Arial";
+	font-family: "Helvetica Neue";
 }
 
 #condaBox {

--- a/collaborators/index.html
+++ b/collaborators/index.html
@@ -2,9 +2,9 @@
 title: Collaborators
 description: pyiron benefits greatly from its broad, diverse network of collaborators and users.
 ---
-<p class="editor-link" style="text-align: center;"><a href="cloudcannon:collections/_collaborators/" class="btn"><strong>&#9998;</strong> Manage Collaborators</a></p>
+
 <p style="text-align: center;">
-	Interested in testing pyiron yourself? <a href="/getting-started">Try it on Mybinder</a>
+	Interested in testing pyiron yourself? <a href="{{ 'getting-started' | relative_url }}">Try it on Mybinder</a>
 	or install it via <a href="https://anaconda.org/conda-forge/pyiron">conda</a>
 	/<a href="https://github.com/pyiron/pyiron">Github</a>.
 </p>
@@ -12,7 +12,7 @@ description: pyiron benefits greatly from its broad, diverse network of collabor
 	{% for institute in site.data.collaborators %}
 		<li>
 			<a href="{{ institute.link }}" target="_blank">
-			<div class="collaborator-image"><img src="{% include relative-src.html src=institute.image_path %}" alt="{{ institute.name }}"/></div>
+			<div class="collaborator-image"><img src="{{ institute.image_path | relative_url }}" alt="{{ institute.name }}"/></div>
 			<div class="name">{{ institute.name }}</div>
 			<div class="location">{{ institute.location }}</div>
 			</a>
@@ -31,7 +31,7 @@ description: pyiron benefits greatly from its broad, diverse network of collabor
 			<div class="collaborator-block">
 				<a href="{{ collaborator.link }}" target="_blank">
 					<div class="square-image">
-						<img src="{{ collaborator.image_path }}" alt="{{ collaborator.name }}" class="editable">
+						<img src="{{ collaborator.image_path | relative_url }}" alt="{{ collaborator.name }}" class="editable">
 						<h2>{{ collaborator.name }}</h2>
 					</div>
 				</a>

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -31,5 +31,5 @@ description:
 <p>
     You can also find a number of advanced workflows and specific simulation
     protocols in the notebooks accompanying papers under
-    <a href="/publications">publications</a>.
+    <a href="{{ 'publications' | relative_url }}">publications</a>.
 </p>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ description: Optimized protocols and data management for high-powered research
 			>
 		<h3 style="color: {{ site.colors.main }}">{{ post.date | date: "%b %d, %Y"  }}</h3>
 		<p>
-		<a href="{{ post.url }}">
+		<a href="{{ post.url | relative_url }}">
 			{{ post.title }}
 		</a>
 			<div class="post-details">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 title: The materials science IDE
 description: Optimized protocols and data management for high-powered research
 ---
-<script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
 
 <section class="hero">
 	{% if site.alert %}
@@ -11,14 +10,14 @@ description: Optimized protocols and data management for high-powered research
 			{{ site.alert }}
 		</div>
 	{% endif %}
-	<img class="main-logo" src="images/logo.png"></img>
+	<img class="main-logo" src="{{ 'images/logo.png' | relative_url }}"></img>
 	<div class="text-container">
 		<h1 class="editable"><strong>The materials science IDE</strong></h1>
 		<p class="subtext editable">Open-source protocols and data management for high-powered research</p>
 		<div class="cta button alt"><a href="https://github.com/pyiron/pyiron" target="_blank">Browse on Github</a></div>
 		<div id="condaBox"><code class="prettyprint lang-bash" style="width: auto;">conda install -c conda-forge pyiron</code></div>
 		<div>
-			<img src="{{ site.baseurl }}/images/dashboard.png" alt="Screenshot" class="screenshot editable" />
+			<img src="{{ 'images/dashboard.png' | relative_url }}" alt="Screenshot" class="screenshot editable" />
 		</div>
 	</div>
 </section>
@@ -38,7 +37,7 @@ description: Optimized protocols and data management for high-powered research
 				</p>
 			</div>
 			<div class="image">
-				<img src="{{ site.baseurl }}/images/database.png" alt="Server" class="editable" />
+				<img src="{{ 'images/database.png' | relative_url }}" alt="Server" class="editable" />
 			</div>
 		</div>
 	</section>
@@ -54,7 +53,7 @@ description: Optimized protocols and data management for high-powered research
 					interactive Python notebooks.</p>
 			</div>
 			<div class="image">
-				<img src="{{ site.baseurl }}/images/workflow.png" alt="Workflow" class="editable" />
+				<img src="{{ 'images/workflow.png' | relative_url }}" alt="Workflow" class="editable" />
 			</div>
 		</div>
 	</section>
@@ -72,7 +71,7 @@ description: Optimized protocols and data management for high-powered research
 				</p>
 			</div>
 			<div class="image">
-				<img src="{{ site.baseurl }}/images/tools.png" alt="Tools" class="editable" />
+				<img src="{{ 'images/tools.png' | relative_url }}" alt="Tools" class="editable" />
 			</div>
 		</div>
 	</section>
@@ -86,9 +85,9 @@ description: Optimized protocols and data management for high-powered research
 	{% for post in site.categories.news limit:3 %}
 		<div class="news-card"
 		{% if news_icons contains post.categories[1] %}
-			style="background-image: url(/images/news-icon-{{ post.categories[1] }}.png)"
+			style="background-image: url({{ site.baseurl }}/images/news-icon-{{ post.categories[1] }}.png)"
 		{% else %}
-			style="background-image: url(/images/news-icon-default.png)"
+			style="background-image: url({{ site.baseurl }}/images/news-icon-default.png)"
 		{% endif %}
 			>
 		<h3 style="color: {{ site.colors.main }}">{{ post.date | date: "%b %d, %Y"  }}</h3>

--- a/license/index.html
+++ b/license/index.html
@@ -5,14 +5,14 @@ description:
 <div class="container no-padding">
     <h3>Codebase</h3>
     <ul>
-        <li><p>pyiron is released under the terms of the <a href="/BSD_LICENSE" download>BSD 3-clause license</a>.</p></li>
+        <li><p>pyiron is released under the terms of the <a href="{{ 'BSD_LICENSE' | relative_url }}" download>BSD 3-clause license</a>.</p></li>
     </ul>
     <h3>Website</h3>
     <ul>
         <li>
             <p>If you would like to link pyiron in a presentation, please use this QR code (directs to pyiron.org)</p>
         </li>
-        <img style="width: 250px;" src="{{ site.base_url }}/images/qr-code.png"></img>
+        <img style="width: 250px;" src="{{ 'images/qr-code.png' | relative_url }}"></img>
 
         <li><p>Homepage icons made by <a href="https://www.flaticon.com/authors/freepik" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></p></li>
     </ul>

--- a/team/index.html
+++ b/team/index.html
@@ -5,7 +5,6 @@ full_width: true
 ---
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 <div class="container">
-	<p class="editor-link" style="text-align: center;"><a href="cloudcannon:collections/_staff_members/" class="btn"><strong>&#9998;</strong> Manage Staff members</a></p>
 	<p style="text-align: center;">
 		Interested in contributing to pyiron? <a onclick="$('#formbutton-button')[0].click();">Contact us</a>
 		or open an <a href="https://github.com/pyiron/pyiron/issues">issue</a>/
@@ -15,7 +14,7 @@ full_width: true
 	<ul class="developers">
 		{% for person in site.data.core-developers %}
 			<li id="{{ person.links.github }}">
-				<div class="square-image"><img src="{% include relative-src.html src=person.image_path %}" alt="{{ person.name }}"/></div>
+				<div class="square-image"><img src="{{ person.image_path | relative_url }}" alt="{{ person.name }}"/></div>
 				<div class="name">{{ person.name }}</div>
 				<div class="info">{{ person.position }}</div>
 				<div class="links">


### PR DESCRIPTION
All of our internal src's and href's throughout the site have been wrapped in a jekyll `relative_url` filter like this:

`<a href="{{ post.url | relative_url }}">`

or have {{ site.baseurl }} as their prefix, like this:

`<a href="{{ site.baseurl }}/news#category={{ category | slugify }}">`

This won't change the behavior on pyiron.org at all, but is the recommended strategy for jekyll and will allow internal links to work regardless of where the site is being hosted (particularly relevant for #83).

I will host this branch live until tomorrow morning [here](https://www.michael-ashton.com/pyiron_beta) if anyone wants to try breaking it. After that I'll plan to merge it since it's working stably for me.