### PR TITLE
Center blog post content

### DIFF
--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -12,7 +12,7 @@
 }
 
 .blog-post {
-	margin: 100px 0px 100px 0px !important;
+	margin: 100px auto 0px;
 
 	.author {
 		padding: 30px 0 0 0;


### PR DESCRIPTION
I messed up and had the blog post text left-aligned, which looked weird on big screens. Now they're center-aligned.