### PR TITLE
Slightly enlarge news cards

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -102,7 +102,7 @@
 
 	.news-card {
 		width: 200px;
-		height: 200px;
+		min-height: 240px;
 	}
 
 	.content section:nth-child(even) .flex {


### PR DESCRIPTION
So that the text doesn't bleed over the edge.

Before:
<img width="1118" alt="Screen Shot 2020-10-09 at 11 58 38" src="https://user-images.githubusercontent.com/16377664/95570238-ea3f8b00-0a26-11eb-8480-6f972498fd01.png">
---
After:
<img width="1132" alt="Screen Shot 2020-10-09 at 11 59 18" src="https://user-images.githubusercontent.com/16377664/95570249-ef9cd580-0a26-11eb-96da-ffda6a0642aa.png">
---
